### PR TITLE
Bypassing planemo url linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         mode: lint
         repository-list: ${{ needs.setup.outputs.repository-list }}
         tool-list: ${{ needs.setup.outputs.tool-list }}
-        additional-planemo-options: --biocontainers -s tests,output,inputs,help,general,command,citations,tool_xsd,xml_order,tool_urls,shed_metadata
+        additional-planemo-options: --biocontainers -s tests,output,inputs,help,general,command,citations,tool_xsd,xml_order,shed_metadata
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:


### PR DESCRIPTION
Possible fix for this https://github.com/esg-epfl-apc/tools-astro/pull/208#issuecomment-2835512860

I made some test locally but it seems that with latest versions of planemo the --urls flag needs to be added to lint urls otherwise the check is skipped

Also urls is not skippable using planemo lint --skip 'urls' because it's not part of the list of linting tests

I'm not totally sure "tool_urls" is responsible for that as I couldn't find it in the documentation but looking at this issue https://github.com/galaxyproject/planemo/issues/677 it seems that at some point it was part of the lint test cases so I guess it's worth a shot 

Possibly due to the use of cache action the ci is still using some old version of planemo where urls are checked by default but not sure about that